### PR TITLE
FEAT: Added --setup as CLI option for screenshot and compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 - [Install](#install)
 - [Taking screenshots](#taking-screenshots)
 	- [screenshot CLI Options](#screenshot-cli-options)
-	- [Config the __`setup.json`__](#config-the-__setupjson__)
+	- [Config the __`setup.json`__](#config-the-setupjson)
 		- [Parameters](#parameters)
 			- [Sample file:](#sample-file)
-	- [Config the __`pages.json`__](#config-the-__pagesjson__)
+	- [Config the __`pages.json`__](#config-the-pagesjson)
 		- [Parameters](#parameters-1)
 			- [Sample file:](#sample-file-1)
 - [Comparing screenshots](#comparing-screenshots)
@@ -44,6 +44,8 @@ $ node screenshot.js
                              "headless" parameter from the setup.json file.
   -p, --pages String         The path to the pages.json file. Default option uses pages.json from the root
                              of the project.
+  -s, --setup String        Path to the setup file. Default option uses setup.json from the root of the
+                             project.
 
 ```
 
@@ -203,6 +205,8 @@ Options List
   -b, --base String       Path to the folder used as the base for comparison.
   -c, --compare String    Path to the folder used for comparison against the base folder.
   -d, --dry-run           Compares the images without saving the diff files.
+  -s, --setup String      Path to the setup file. Default option uses setup.json from the root of the
+                          project.
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "master-of-puppets",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "A set of tools for visual regression test for an entire website.",
 	"main": "screenshot.js",
 	"repository": "github:nalmeida/master-of-puppets",
@@ -8,7 +8,8 @@
 		"node": ">=14"
 	},
 	"scripts": {
-		"serve:test": "http-server ./web -c-1"
+		"test": "node test.js",
+		"serve:test": "http-server ./web -c-1 -p 8080"
 	},
 	"keywords": [],
 	"author": "Nicholas Almeida",

--- a/screenshot.js
+++ b/screenshot.js
@@ -85,7 +85,7 @@ var init = function (commandLineObject) {
 
 	util.logLevel = logLevel = !isNaN(commandLineObject.loglevel) ? commandLineObject.loglevel : 0;
 
-	var setupFile = 'setup.json';
+	var setupFile = commandLineObject.setup || 'setup.json';
 	domainConfig = commandLineObject.domain || undefined;
 	headlessConfig = commandLineObject.headless || undefined;
 	authConfig = commandLineObject.auth || undefined;
@@ -371,6 +371,12 @@ const sections = [
 				alias: 'p',
 				typeLabel: '{underline String}',
 				description: 'The path to the {italic pages.json} file. Default option uses {italic pages.json} from the root of the project.'
+			},
+			{
+				name: 'setup',
+				alias: 's',
+				typeLabel: '{underline String}',
+				description: 'The path to the {italic setup.json} file. Default option uses {italic setup.json} from the root of the project.'
 			}
 		]
 	}
@@ -383,7 +389,8 @@ const optionDefinitions = [
 	{ name: 'domain', alias: 'd', type: String },
 	{ name: 'auth', alias: 'a', type: String },
 	{ name: 'headless', alias: 'e', type: String },
-	{ name: 'pages', alias: 'p', type: String }
+	{ name: 'pages', alias: 'p', type: String },
+	{ name: 'setup', alias: 's', type: String }
 ]
 const options = commandLineArgs(optionDefinitions);
 


### PR DESCRIPTION
This pull request introduces a new CLI option to allow users to specify a custom `setup.json` file via the `--setup` or `-s` flag in both the `screenshot.js` and `compare.js` tools. The documentation has been updated accordingly, and the default behavior still uses `setup.json` from the project root if no custom path is provided. Additionally, the package version is bumped to 1.4.0 and a test script is added.

### CLI Enhancements

* Added a `--setup` (`-s`) option to both `screenshot.js` and `compare.js` for specifying the path to a `setup.json` file. If not provided, it defaults to `setup.json` in the project root. [[1]](diffhunk://#diff-ffb35c4e1cca724e6787fb3774da04e864cc7fc240540ce69a799004fde036f9L88-R88) [[2]](diffhunk://#diff-ffb35c4e1cca724e6787fb3774da04e864cc7fc240540ce69a799004fde036f9R374-R379) [[3]](diffhunk://#diff-ffb35c4e1cca724e6787fb3774da04e864cc7fc240540ce69a799004fde036f9L386-R393) [[4]](diffhunk://#diff-a19b234cb213985665b6a4fa78144d7c72ac61dc1a0b4e6f7b86c22ff89c235aR162-R168) [[5]](diffhunk://#diff-a19b234cb213985665b6a4fa78144d7c72ac61dc1a0b4e6f7b86c22ff89c235aL170-R188)

### Documentation Updates

* Updated `README.md` to document the new `--setup` CLI option and corrected anchor links for configuration sections. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R47-R48) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R208-R209)

### Project Metadata

* Bumped the package version to 1.4.0 and added a `test` script to `package.json`.